### PR TITLE
Fix quantity increment and update button labels

### DIFF
--- a/assets/double-qty.js
+++ b/assets/double-qty.js
@@ -6,7 +6,7 @@
   // Configurări
   var BUTTON_CLASS = 'double-qty-btn';
   var LABEL_PREFIX = 'Adaugă ';
-  var LABEL_SUFFIX = ' de bucăți';
+  var LABEL_SUFFIX = ' bucăți';
 
   // Setează valoarea minimă definită în data-min-qty
   function applyMinQty(){
@@ -81,7 +81,14 @@
     });
   }
 
+  // Attach increment/decrement handlers only if the theme doesn't provide its own
+  // quantity-input custom element. Previously both scripts ran and doubled the
+  // step value on each click.
   function initQuantityButtons(){
+    if(window.customElements && window.customElements.get('quantity-input')){
+      // Theme already handles quantity buttons; avoid duplicate increments
+      return;
+    }
     document.querySelectorAll('[data-quantity-selector="increase"]').forEach(function(btn){
       if(btn.dataset.stepApplied) return;
       btn.dataset.stepApplied = '1';

--- a/snippets/double-qty-btn.liquid
+++ b/snippets/double-qty-btn.liquid
@@ -11,9 +11,9 @@
 {% endif %}
 <button type="button"
         class="double-qty-btn sf__btn sf__btn-secondary"
-        aria-label="Adaugă {{ min_qty }} de bucăți"
+        aria-label="Adaugă {{ min_qty }} bucăți"
         data-double-qty>
-    Adaugă {{ min_qty }} de bucăți
+    Adaugă {{ min_qty }} bucăți
 </button>
 
 

--- a/snippets/product-qty-input.liquid
+++ b/snippets/product-qty-input.liquid
@@ -39,9 +39,9 @@
     {%- assign min_qty = product.metafields.custom.minimum_quantity | default: 1 -%}
     <button type="button"
         class="double-qty-btn sf__btn sf__btn-secondary flex-1 max-w-[160px]"
-        aria-label="Adaugă {{ min_qty }} de bucăți"
+        aria-label="Adaugă {{ min_qty }} bucăți"
         data-double-qty>
-        Adaugă {{ min_qty }} de bucăți
+        Adaugă {{ min_qty }} bucăți
     </button>
   {%- endif -%}
 </div>


### PR DESCRIPTION
## Summary
- avoid double increments from custom quantity JS
- remove "de" from "Adaugă X bucăți" label

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688759179520832db4a116f5683b93e0