### PR TITLE
Fix quantity increment and load unminified script

### DIFF
--- a/assets/double-qty.js
+++ b/assets/double-qty.js
@@ -6,7 +6,7 @@
   // Configurări
   var BUTTON_CLASS = 'double-qty-btn';
   var LABEL_PREFIX = 'Adaugă ';
-  var LABEL_SUFFIX = ' de bucăți';
+  var LABEL_SUFFIX = ' bucăți';
 
   // Setează valoarea minimă definită în data-min-qty
   function applyMinQty(){
@@ -29,6 +29,7 @@
     if(newVal < min) newVal = min;
     if(newVal > max) newVal = max;
     input.value = newVal;
+    input.style.color = newVal >= max ? '#e3342f' : '';
     input.dispatchEvent(new Event('input', { bubbles: true }));
     input.dispatchEvent(new Event('change', { bubbles: true }));
   }
@@ -65,6 +66,7 @@
         var max = input.max ? parseInt(input.max, 10) : 9999;
         var val = parseInt(input.value, 10) || 1;
         btn.disabled = val >= max;
+        input.style.color = val >= max ? '#e3342f' : '';
       }
       updateBtnState();
       input.addEventListener('input', updateBtnState);
@@ -81,7 +83,14 @@
     });
   }
 
+  // Attach increment/decrement handlers only if the theme doesn't provide its own
+  // quantity-input custom element. Previously both scripts ran and doubled the
+  // step value on each click.
   function initQuantityButtons(){
+    if(window.customElements && window.customElements.get('quantity-input')){
+      // Theme already handles quantity buttons; avoid duplicate increments
+      return;
+    }
     document.querySelectorAll('[data-quantity-selector="increase"]').forEach(function(btn){
       if(btn.dataset.stepApplied) return;
       btn.dataset.stepApplied = '1';
@@ -105,10 +114,11 @@
   }
 
   // Rulează la pageload și la re-render (dacă ai AJAX sau Shopify section load)
+  // Nu mai atașăm handler-ele proprii pe butoanele +/- deoarece tema deja
+  // gestionează aceste evenimente. Astfel evităm dublarea pasului la click.
   function initAll(){
     applyMinQty();
     initDoubleQtyButtons();
-    initQuantityButtons();
   }
   document.addEventListener('DOMContentLoaded', initAll);
   window.addEventListener('shopify:section:load', initAll);

--- a/layout/password.liquid
+++ b/layout/password.liquid
@@ -47,7 +47,7 @@
     {% render 'custom-code-body' %}
     {% render 'foxkit-messenger' %}
     {% render 'script-tags' %}
-    <script src="{{ 'app.min.js' | asset_url }}" defer="defer"></script>
+    <script src="{{ 'app.js' | asset_url }}" defer="defer"></script>
     <script src="{{ 'foxkit-app.min.js' | asset_url }}" defer="defer"></script>
 
     {% if settings.show_quickview_button %}

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -89,7 +89,7 @@ template-{{ template.name | handle }} {{ template.name }}-{{ template.suffix }} 
   {% render 'foxkit-messenger' %}
   {% render 'script-tags' %}
 
-  <script src="{{ 'app.min.js' | asset_url }}" defer="defer"></script>
+  <script src="{{ 'app.js' | asset_url }}" defer="defer"></script>
   <script src="{{ 'foxkit-app.min.js' | asset_url }}" defer="defer"></script>
 
   <script src="{{ 'quick-view.min.js' | asset_url }}" defer="defer"></script>

--- a/snippets/double-qty-btn.liquid
+++ b/snippets/double-qty-btn.liquid
@@ -11,9 +11,9 @@
 {% endif %}
 <button type="button"
         class="double-qty-btn sf__btn sf__btn-secondary"
-        aria-label="Adaugă {{ min_qty }} de bucăți"
+        aria-label="Adaugă {{ min_qty }} bucăți"
         data-double-qty>
-    Adaugă {{ min_qty }} de bucăți
+    Adaugă {{ min_qty }} bucăți
 </button>
 
 

--- a/snippets/preload.liquid
+++ b/snippets/preload.liquid
@@ -13,7 +13,7 @@
 <link rel="preconnect" href="{{ canonical_url }}" crossorigin>
 <link rel="preconnect" href="https://cdn.shopify.com" crossorigin>
 <link rel="preload" as="style" href="{{ 'chunk.css' | asset_url }}">
-<link rel="preload" as="script" href="{{ 'app.min.js' | asset_url }}">
+<link rel="preload" as="script" href="{{ 'app.js' | asset_url }}">
 <link rel="preload" as="script" href="{{ 'foxkit-app.min.js' | asset_url }}">
 <link rel="preload" as="script" href="{{ 'lazy-image.min.js' | asset_url }}">
 {% comment %} End ConceptSGM prefetch resources {% endcomment %}

--- a/snippets/product-qty-input.liquid
+++ b/snippets/product-qty-input.liquid
@@ -39,9 +39,9 @@
     {%- assign min_qty = product.metafields.custom.minimum_quantity | default: 1 -%}
     <button type="button"
         class="double-qty-btn sf__btn sf__btn-secondary flex-1 max-w-[160px]"
-        aria-label="Adaugă {{ min_qty }} de bucăți"
+        aria-label="Adaugă {{ min_qty }} bucăți"
         data-double-qty>
-        Adaugă {{ min_qty }} de bucăți
+        Adaugă {{ min_qty }} bucăți
     </button>
   {%- endif -%}
 </div>


### PR DESCRIPTION
## Summary
- adjust quantity buttons only once to prevent double increments
- highlight quantity input when reaching stock limit
- load unminified `app.js` so updates apply

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688759179520832db4a116f5683b93e0