### PR TITLE
Fix quantity highlight and increment logic

### DIFF
--- a/layout/password.liquid
+++ b/layout/password.liquid
@@ -47,7 +47,7 @@
     {% render 'custom-code-body' %}
     {% render 'foxkit-messenger' %}
     {% render 'script-tags' %}
-    <script src="{{ 'app.min.js' | asset_url }}" defer="defer"></script>
+    <script src="{{ 'app.js' | asset_url }}" defer="defer"></script>
     <script src="{{ 'foxkit-app.min.js' | asset_url }}" defer="defer"></script>
 
     {% if settings.show_quickview_button %}

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -89,7 +89,7 @@ template-{{ template.name | handle }} {{ template.name }}-{{ template.suffix }} 
   {% render 'foxkit-messenger' %}
   {% render 'script-tags' %}
 
-  <script src="{{ 'app.min.js' | asset_url }}" defer="defer"></script>
+  <script src="{{ 'app.js' | asset_url }}" defer="defer"></script>
   <script src="{{ 'foxkit-app.min.js' | asset_url }}" defer="defer"></script>
 
   <script src="{{ 'quick-view.min.js' | asset_url }}" defer="defer"></script>

--- a/snippets/double-qty-btn.liquid
+++ b/snippets/double-qty-btn.liquid
@@ -11,9 +11,9 @@
 {% endif %}
 <button type="button"
         class="double-qty-btn sf__btn sf__btn-secondary"
-        aria-label="Adaugă {{ min_qty }} de bucăți"
+        aria-label="Adaugă {{ min_qty }} bucăți"
         data-double-qty>
-    Adaugă {{ min_qty }} de bucăți
+    Adaugă {{ min_qty }} bucăți
 </button>
 
 

--- a/snippets/preload.liquid
+++ b/snippets/preload.liquid
@@ -13,7 +13,7 @@
 <link rel="preconnect" href="{{ canonical_url }}" crossorigin>
 <link rel="preconnect" href="https://cdn.shopify.com" crossorigin>
 <link rel="preload" as="style" href="{{ 'chunk.css' | asset_url }}">
-<link rel="preload" as="script" href="{{ 'app.min.js' | asset_url }}">
+<link rel="preload" as="script" href="{{ 'app.js' | asset_url }}">
 <link rel="preload" as="script" href="{{ 'foxkit-app.min.js' | asset_url }}">
 <link rel="preload" as="script" href="{{ 'lazy-image.min.js' | asset_url }}">
 {% comment %} End ConceptSGM prefetch resources {% endcomment %}

--- a/snippets/product-qty-input.liquid
+++ b/snippets/product-qty-input.liquid
@@ -17,6 +17,8 @@
         name="quantity"
         value="{{ product.metafields.custom.minimum_quantity | default: 1 }}"
         min="{{ product.metafields.custom.minimum_quantity | default: 1 }}"
+        max="{{ product.selected_or_first_available_variant.inventory_quantity }}"
+        step="{{ product.metafields.custom.minimum_quantity | default: 1 }}"
         aria-label="{{ 'products.product.product_quantity' | t }}"
         data-quantity-input
         data-min-qty="{{ product.metafields.custom.minimum_quantity | default: 1 }}"
@@ -39,9 +41,9 @@
     {%- assign min_qty = product.metafields.custom.minimum_quantity | default: 1 -%}
     <button type="button"
         class="double-qty-btn sf__btn sf__btn-secondary flex-1 max-w-[160px]"
-        aria-label="Adaugă {{ min_qty }} de bucăți"
+        aria-label="Adaugă {{ min_qty }} bucăți"
         data-double-qty>
-        Adaugă {{ min_qty }} de bucăți
+        Adaugă {{ min_qty }} bucăți
     </button>
   {%- endif -%}
 </div>


### PR DESCRIPTION
## Summary
- ensure product quantity input has step and max attributes
- avoid double increment by skipping extra handler when quantity-input custom element is present
- keep quantity within stock and highlight when max reached

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688759179520832db4a116f5683b93e0