### PR TITLE
Fix double qty button behaviour

### DIFF
--- a/assets/double-qty.js
+++ b/assets/double-qty.js
@@ -27,18 +27,18 @@
   var LABEL_PREFIX = 'Adaugă ';
   var LABEL_SUFFIX = ' bucăți';
 
-  // Setează valoarea minimă definită în data-min-qty
+  // Setează valoarea minimă definită în data-min-qty și atașează validarea
   function applyMinQty(){
-    document.querySelectorAll('[data-min-qty]').forEach(function(input){
-      var min = parseInt(input.getAttribute('data-min-qty'), 10);
-      if(min && min > 0){
-        input.min = min;
-        input.step = min;
-        if(parseInt(input.value,10) < min){
-          input.value = min;
-        }
-        validateAndHighlightQty(input);
+    document.querySelectorAll('input[data-min-qty]').forEach(function(input){
+      var min = parseInt(input.getAttribute('data-min-qty'), 10) || 1;
+      input.min = min;
+      input.step = min;
+      if(!input.dataset.qtyListener){
+        input.addEventListener('input', function(){ validateAndHighlightQty(input); });
+        input.addEventListener('change', function(){ validateAndHighlightQty(input); });
+        input.dataset.qtyListener = '1';
       }
+      validateAndHighlightQty(input);
     });
   }
 
@@ -99,6 +99,7 @@
       }
       updateBtnState();
       input.addEventListener('input', updateBtnState);
+      input.addEventListener('change', updateBtnState);
 
       // Click: adaugă pasul minim (la fel ca la butonul plus)
       btn.addEventListener('click', function(e){

--- a/snippets/cart-line-item.liquid
+++ b/snippets/cart-line-item.liquid
@@ -202,7 +202,10 @@
             name="updates[]"
             data-id="{{- item.key -}}"
             value="{{ item.quantity }}"
-            min="0"
+            min="{{ item.product.metafields.custom.minimum_quantity | default: 1 }}"
+            step="{{ item.product.metafields.custom.minimum_quantity | default: 1 }}"
+            max="{{ item.variant.inventory_quantity }}"
+            data-min-qty="{{ item.product.metafields.custom.minimum_quantity | default: 1 }}"
           />
           <button class="scd-item__btn" data-id="{{- item.key -}}" data-qty-change="inc">+</button>
         </div>
@@ -224,7 +227,10 @@
         name="updates[]"
         data-id="{{- item.key -}}"
         value="{{ item.quantity }}"
-        min="0"
+        min="{{ item.product.metafields.custom.minimum_quantity | default: 1 }}"
+        step="{{ item.product.metafields.custom.minimum_quantity | default: 1 }}"
+        max="{{ item.variant.inventory_quantity }}"
+        data-min-qty="{{ item.product.metafields.custom.minimum_quantity | default: 1 }}"
       />
       <button class="scd-item__btn" data-id="{{- item.key -}}" data-qty-change="inc">+</button>
     </div>


### PR DESCRIPTION
## Summary
- handle qty min and validation in `double-qty.js`
- set min/step/max and `data-min-qty` on cart quantity inputs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688789a2060c832d8f5bc9fcb576c741