### PR TITLE
Fix double qty button visibility in theme editor

### DIFF
--- a/snippets/double-qty-btn.liquid
+++ b/snippets/double-qty-btn.liquid
@@ -9,7 +9,7 @@
 {% elsif item %}
   {% assign min_qty = item.product.metafields.custom.minimum_quantity | default: 1 %}
 {% endif %}
-{% if min_qty > 1 %}
+{% if min_qty > 1 or request.design_mode %}
 <button type="button"
         class="double-qty-btn sf__btn sf__btn-secondary"
         aria-label="Adaugă {{ min_qty }} bucăți"

--- a/snippets/product-qty-input.liquid
+++ b/snippets/product-qty-input.liquid
@@ -39,7 +39,7 @@
 
   {%- if show_double_qty_btn != false -%}
     {%- assign min_qty = product.metafields.custom.minimum_quantity | default: 1 -%}
-    {%- if min_qty > 1 -%}
+    {%- if min_qty > 1 or request.design_mode -%}
     <button type="button"
         class="double-qty-btn sf__btn sf__btn-secondary flex-1 max-w-[160px]"
         aria-label="Adaugă {{ min_qty }} bucăți"


### PR DESCRIPTION
## Summary
- ensure the "double quantity" button renders while customizing the theme

## Testing
- `npm test` *(fails: ENOENT: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6887ae4d5348832da4f2c1bce8ab72e9