### PR TITLE
Fix quantity decrement snapping for product selectors

### DIFF
--- a/assets/double-qty.js
+++ b/assets/double-qty.js
@@ -80,12 +80,13 @@
     document.addEventListener('click', function(e){
       var btn = e.target.closest('[data-quantity-selector],[data-qty-change]');
       if(!btn) return;
-      var container = btn.closest('.quantity-input') || btn.parentNode;
-      var input = container.querySelector('input[type="number"]');
-      if(input){
-        setTimeout(function(){ validateAndHighlightQty(input); }, 0);
-      }
-    });
+      if(btn.closest('.scd-item') || btn.closest('[data-cart-item]')) return;
+      var input = findQtyInput(btn);
+      if(!input) return;
+      e.preventDefault();
+      var delta = (btn.dataset.quantitySelector === 'increase' || btn.dataset.qtyChange === 'inc') ? 1 : -1;
+      adjustQuantity(input, delta);
+    }, true);
   }
 
   function adjustQuantity(input, delta){


### PR DESCRIPTION
## Summary
- correct quantity button logic for product page and sticky ATC

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887f9cd1994832d8505c25116f60234