### PR TITLE
Fix quantity decrement snapping for product selectors

### DIFF
--- a/assets/double-qty.js
+++ b/assets/double-qty.js
@@ -9,11 +9,16 @@
     return Math.floor((val - min) / step) * step + min;
   }
 
-  function clampAndSnap(val, step, min, max){
+  function clampAndSnap(val, step, min, max, wasAtMax){
+    var original = val;
     val = Math.min(val, max);
     if(val < min) val = min;
     if(val !== max){
-      val = snapDown(val, step, min);
+      if(wasAtMax && original === max - step && (max % step !== 0)){
+        val = snapDown(max, step, min);
+      }else{
+        val = snapDown(val, step, min);
+      }
     }
     return val;
   }
@@ -23,15 +28,18 @@
     var min = parseInt(input.min, 10) || step;
     var max = input.max ? parseInt(input.max, 10) : Infinity;
     var val = parseInt(input.value, 10);
+    var wasAtMax = input.dataset.atMax === '1';
     val = isNaN(val) ? min : val;
-    val = clampAndSnap(val, step, min, max);
+    val = clampAndSnap(val, step, min, max, wasAtMax);
     input.value = val;
     if(val >= max){
       input.classList.add('text-red-600');
       input.style.color = '#e3342f';
+      input.dataset.atMax = '1';
     }else{
       input.classList.remove('text-red-600');
       input.style.color = '';
+      input.dataset.atMax = '';
     }
     return val;
   }
@@ -80,12 +88,15 @@
     document.addEventListener('click', function(e){
       var btn = e.target.closest('[data-quantity-selector],[data-qty-change]');
       if(!btn) return;
-      var container = btn.closest('.quantity-input') || btn.parentNode;
-      var input = container.querySelector('input[type="number"]');
-      if(input){
-        setTimeout(function(){ validateAndHighlightQty(input); }, 0);
-      }
-    });
+      if(btn.closest('.scd-item') || btn.closest('[data-cart-item]')) return;
+      var input = findQtyInput(btn);
+      if(!input) return;
+      e.preventDefault();
+      e.stopPropagation();
+      e.stopImmediatePropagation();
+      var delta = (btn.dataset.quantitySelector === 'increase' || btn.dataset.qtyChange === 'inc') ? 1 : -1;
+      adjustQuantity(input, delta);
+    }, true);
   }
 
   function adjustQuantity(input, delta){
@@ -111,15 +122,18 @@
       if(val > max) val = max;
     }
 
-    var newVal = clampAndSnap(val, step, min, max);
+    var wasAtMax = input.dataset.atMax === '1';
+    var newVal = clampAndSnap(val, step, min, max, wasAtMax);
     input.value = newVal;
     // Colorare roșie la maxim
     if(newVal >= max){
       input.classList.add('text-red-600');
       input.style.color = '#e3342f';
+      input.dataset.atMax = '1';
     }else{
       input.classList.remove('text-red-600');
       input.style.color = '';
+      input.dataset.atMax = '';
     }
     input.dispatchEvent(new Event('input', { bubbles: true }));
     input.dispatchEvent(new Event('change', { bubbles: true }));


### PR DESCRIPTION
## Summary
- correct click handler so default theme events no longer double-trigger

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6887f9cd1994832d8505c25116f60234