### PR TITLE
Handle quantity buttons when theme doesn't change input

### DIFF
--- a/assets/double-qty.js
+++ b/assets/double-qty.js
@@ -87,8 +87,21 @@
       var container = btn.closest('.quantity-input') || btn.parentNode;
       var input = container.querySelector('input[type="number"]');
       if(input){
-        // Tema gestionează deja incrementarea/decrementarea, noi doar validăm după
-        setTimeout(function(){ validateAndHighlightQty(input); }, 0);
+        var before = input.value;
+        setTimeout(function(){
+          if(input.value === before){
+            var action = btn.getAttribute('data-quantity-selector') || btn.getAttribute('data-qty-change');
+            if(action === 'increase' || action === 'inc'){
+              adjustQuantity(input, 1);
+            }else if(action === 'decrease' || action === 'dec'){
+              adjustQuantity(input, -1);
+            }else{
+              validateAndHighlightQty(input);
+            }
+          }else{
+            validateAndHighlightQty(input);
+          }
+        }, 0);
       }
     }, true);
   }


### PR DESCRIPTION
## Summary
- update the quantity button handler to detect unchanged values and manually adjust
- keep dispatching `input` and `change` events in `adjustQuantity`

## Testing
- `node test-qty.js`

------
https://chatgpt.com/codex/tasks/task_e_68882339e590832d9ddf4477b2bdb3e8