### PR TITLE
Stop adjusting quantity past max

### DIFF
--- a/assets/double-qty.js
+++ b/assets/double-qty.js
@@ -112,6 +112,11 @@
     var max = input.max ? parseInt(input.max, 10) : Infinity;
     var val = parseInt(input.value, 10) || min;
 
+    if(delta > 0 && isFinite(max) && val >= max){
+      validateAndHighlightQty(input);
+      return;
+    }
+
     if(delta < 0){
       // Pentru decremente, când suntem la max și nu e multiplu, snapDown pe max!
       if(isFinite(max) && val >= max){


### PR DESCRIPTION
## Summary
- prevent adjustQuantity from firing when input already at max

## Testing
- `node test-qty.js`

------
https://chatgpt.com/codex/tasks/task_e_68882dcad940832db407c62deae3c22e