### PR TITLE
Stop adjusting quantity past max

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -8904,8 +8904,12 @@ _defineProperty(this, "handleQtyBtnClick", (e, btn) => {
   let newQty = currentQty;
 
   if (quantitySelector !== 'decrease' && isFinite(max) && currentQty >= max) {
-    quantityInput.classList.add('text-red-600');
-    quantityInput.style.color = '#e3342f';
+    if (typeof validateAndHighlightQty === 'function') {
+      validateAndHighlightQty(quantityInput);
+    } else {
+      quantityInput.classList.add('text-red-600');
+      quantityInput.style.color = '#e3342f';
+    }
     return;
   }
 

--- a/assets/app.js
+++ b/assets/app.js
@@ -8899,8 +8899,15 @@ _defineProperty(this, "handleQtyBtnClick", (e, btn) => {
   const attrMax = parseFloat(quantityInput.max);
   if (!Number.isNaN(attrMax)) max = attrMax;
 
-  const currentQty = Number(quantityInput.value) || min;
+  let currentQty = parseInt(quantityInput.value, 10);
+  if (Number.isNaN(currentQty)) currentQty = min;
   let newQty = currentQty;
+
+  if (quantitySelector !== 'decrease' && isFinite(max) && currentQty >= max) {
+    quantityInput.classList.add('text-red-600');
+    quantityInput.style.color = '#e3342f';
+    return;
+  }
 
   const snapDown = v => {
     if (!isFinite(v)) return min;

--- a/assets/double-qty.js
+++ b/assets/double-qty.js
@@ -110,7 +110,13 @@
     var step = parseInt(input.getAttribute('data-min-qty'), 10) || 1;
     var min = parseInt(input.min, 10) || step;
     var max = input.max ? parseInt(input.max, 10) : Infinity;
-    var val = parseInt(input.value, 10) || min;
+    var val = parseInt(input.value, 10);
+    if(isNaN(val)) val = min;
+
+    if(delta > 0 && isFinite(max) && val >= max){
+      validateAndHighlightQty(input);
+      return;
+    }
 
     if(delta < 0){
       // Pentru decremente, când suntem la max și nu e multiplu, snapDown pe max!


### PR DESCRIPTION
## Summary
- prevent adjustQuantity from firing when input already at max
- guard against NaN when reading input value
- same early return for handleQtyBtnClick

## Testing
- `npm test` *(fails: cannot find package.json)*
- `node -e "console.log('node working')"`


------
https://chatgpt.com/codex/tasks/task_e_68882dcad940832db407c62deae3c22e