### PR TITLE
Refine quantity increment handling

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -8885,6 +8885,25 @@ _defineProperty(this, "handleQtyInputChange", e => {
   }
 
   product_ConceptSGMEvents.emit(`${this.productData.id}__QUANTITY_CHANGE`, val, this);
+  this.updateIncreaseBtnState();
+});
+
+_defineProperty(this, "updateIncreaseBtnState", () => {
+  const { quantityInput, quantityBtns } = this.domNodes;
+  if (!quantityInput || !quantityBtns) return;
+  const plusBtn = Array.isArray(quantityBtns)
+    ? quantityBtns.find(b => b.dataset.quantitySelector === 'increase' || b.name === 'plus')
+    : null;
+  if (!plusBtn) return;
+
+  const step = Number(quantityInput.getAttribute('data-min-qty')) || Number(quantityInput.step) || 1;
+  const min = Number(quantityInput.min) || step;
+  let max = this.productData?.selected_variant?.inventory_quantity ?? Infinity;
+  const attrMax = parseFloat(quantityInput.max);
+  if (!Number.isNaN(attrMax)) max = attrMax;
+  let val = parseInt(quantityInput.value, 10);
+  if (Number.isNaN(val)) val = min;
+  plusBtn.disabled = isFinite(max) && val >= max;
 });
 
 
@@ -8899,8 +8918,20 @@ _defineProperty(this, "handleQtyBtnClick", (e, btn) => {
   const attrMax = parseFloat(quantityInput.max);
   if (!Number.isNaN(attrMax)) max = attrMax;
 
-  const currentQty = Number(quantityInput.value) || min;
+  let currentQty = parseInt(quantityInput.value, 10);
+  if (Number.isNaN(currentQty)) currentQty = min;
   let newQty = currentQty;
+
+  if (quantitySelector !== 'decrease' && isFinite(max) && currentQty >= max) {
+    if (typeof validateAndHighlightQty === 'function') {
+      validateAndHighlightQty(quantityInput);
+    } else {
+      quantityInput.classList.add('text-red-600');
+      quantityInput.style.color = '#e3342f';
+    }
+    this.updateIncreaseBtnState();
+    return;
+  }
 
   const snapDown = v => {
     if (!isFinite(v)) return min;
@@ -8936,6 +8967,7 @@ _defineProperty(this, "handleQtyBtnClick", (e, btn) => {
     quantityInput.style.color = '';
   }
 
+  this.updateIncreaseBtnState();
   product_ConceptSGMEvents.emit(`${this.productData.id}__QUANTITY_CHANGE`, newQty, this);
 });
 

--- a/assets/double-qty.js
+++ b/assets/double-qty.js
@@ -37,6 +37,18 @@
     }
     return val;
   }
+  function updateIncreaseBtnState(input){
+    var container = input.closest('.quantity-input') || input.parentNode;
+    if(!container) return;
+    var plus = container.querySelector('[data-quantity-selector="increase"],[data-qty-change="inc"]');
+    if(!plus) return;
+    var max = input.max ? parseInt(input.max, 10) : Infinity;
+    var step = parseInt(input.getAttribute('data-min-qty'), 10) || parseInt(input.step,10) || 1;
+    var min = parseInt(input.min, 10) || step;
+    var val = parseInt(input.value, 10);
+    if(isNaN(val)) val = min;
+    plus.disabled = isFinite(max) && val >= max;
+  }
   window.validateAndHighlightQty = validateAndHighlightQty;
 
   var BUTTON_CLASS = 'double-qty-btn';
@@ -63,12 +75,16 @@
       if(input.dataset.qtyListener) return;
       input.dataset.qtyListener = '1';
       ['input','change','blur'].forEach(function(ev){
-        input.addEventListener(ev, function(){ validateAndHighlightQty(input); });
+        input.addEventListener(ev, function(){
+          validateAndHighlightQty(input);
+          updateIncreaseBtnState(input);
+        });
       });
       input.addEventListener('keypress', function(e){
-        if(e.key === 'Enter'){ validateAndHighlightQty(input); }
+        if(e.key === 'Enter'){ validateAndHighlightQty(input); updateIncreaseBtnState(input); }
       });
       validateAndHighlightQty(input);
+      updateIncreaseBtnState(input);
     });
   }
 
@@ -98,8 +114,10 @@
             }else{
               validateAndHighlightQty(input);
             }
+            updateIncreaseBtnState(input);
           }else{
             validateAndHighlightQty(input);
+            updateIncreaseBtnState(input);
           }
         }, 0);
       }
@@ -110,7 +128,14 @@
     var step = parseInt(input.getAttribute('data-min-qty'), 10) || 1;
     var min = parseInt(input.min, 10) || step;
     var max = input.max ? parseInt(input.max, 10) : Infinity;
-    var val = parseInt(input.value, 10) || min;
+    var val = parseInt(input.value, 10);
+    if(isNaN(val)) val = min;
+
+    if(delta > 0 && isFinite(max) && val >= max){
+      validateAndHighlightQty(input);
+      updateIncreaseBtnState(input);
+      return;
+    }
 
     if(delta < 0){
       // Pentru decremente, când suntem la max și nu e multiplu, snapDown pe max!
@@ -141,6 +166,7 @@
     }
     input.dispatchEvent(new Event('input', { bubbles: true }));
     input.dispatchEvent(new Event('change', { bubbles: true }));
+    updateIncreaseBtnState(input);
   }
 
   function findQtyInput(btn) {
@@ -172,6 +198,7 @@
         var val = parseInt(input.value, 10) || 1;
         btn.disabled = val >= max;
         validateAndHighlightQty(input);
+        updateIncreaseBtnState(input);
       }
       updateBtnState();
       input.addEventListener('input', updateBtnState);


### PR DESCRIPTION
## Summary
- disable increment button when quantity hits the max
- add helper to update increment button state from input events

## Testing
- `npm test` *(fails: could not find package.json)*
- `node test-qty.js` *(fails: module not found)*
- `node -e "console.log('node working')"`


------
https://chatgpt.com/codex/tasks/task_e_68882dcad940832db407c62deae3c22e