### PR TITLE
Fix button state after quantity change

### DIFF
--- a/assets/double-qty.js
+++ b/assets/double-qty.js
@@ -224,6 +224,7 @@
       }
       updateBtnState();
       input.addEventListener('input', updateBtnState);
+      input.addEventListener('change', updateBtnState);
 
       btn.addEventListener('click', function(e){
         e.preventDefault();


### PR DESCRIPTION
## Summary
- update double quantity button state on `change`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888cf9d3d04832d806bc7eb98608982