### PR TITLE
Remove redundant quantity label CSS

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -1,3 +1,0 @@
-.prod__option-label {
-  display: block;
-}


### PR DESCRIPTION
## Summary
- remove unused `.prod__option-label` rule from `custom.css`

## Testing
- `grep -o "\.prod__option-label__quantity{[^}]*}" assets/product.css`


------
https://chatgpt.com/codex/tasks/task_e_6888fef4a258832daba5f4bc9be5d385