### PR TITLE
Fix quick add button toggle handling

### DIFF
--- a/sections/custom-content.liquid
+++ b/sections/custom-content.liquid
@@ -282,6 +282,7 @@
                                               is_preorder: is_preorder,
                                               enable_dynamic_checkout: block.settings.enable_payment_button,
                                               show_quantity_selector: block.settings.show_quantity_selector,
+                                              show_double_qty_btn: false,
                                               enableCardButton: block.settings.show_add_to_cart
                                             %}
                                         {% else %}

--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -114,9 +114,10 @@
 							product_form_id: product_form_id,
               product_form_class: product_form_class,
               current_variant: current_variant,
-							is_preorder: is_preorder,
+                                                        is_preorder: is_preorder,
               enable_dynamic_checkout: section.settings.enable_payment_button,
-              show_quantity_selector: section.settings.show_quantity_selector
+              show_quantity_selector: section.settings.show_quantity_selector,
+              show_double_qty_btn: false
             %}
           {% else %}
             <div class="flex flex-wrap mb-5">

--- a/sections/product-quickview.liquid
+++ b/sections/product-quickview.liquid
@@ -41,6 +41,7 @@
               product_form_class: product_form_class,
               current_variant: current_variant,
               show_quantity_selector: true,
+              show_double_qty_btn: false,
               show_sizeguide: false
           %}
         </div>

--- a/snippets/product-form.liquid
+++ b/snippets/product-form.liquid
@@ -25,6 +25,10 @@
   if enableCardButton == nil
     assign enableCardButton = true
   endif
+
+  if show_double_qty_btn == nil
+    assign show_double_qty_btn = section.settings.show_double_qty_btn | default: false
+  endif
 -%}
 
 <div class="form__error-message-wrapper hidden" data-error-message-wrapper role="alert">
@@ -66,10 +70,7 @@
           <div class="flex flex-wrap items-end">
             {% if show_quantity_selector == true %}
               <div class="form__input-wrapper form__input-wrapper--select mr-5 w-32" data-quantity-input-wrapper>
-                {% comment %}
-                  FOLOSEȘTE PARAMETRUL CORECT DIN SECTION, NU BLOCK!
-                {% endcomment %}
-                {% render 'product-qty-input', product_form_id: product_form_id, show_double_qty_btn: section.settings.show_double_qty_btn %}
+                {% render 'product-qty-input', product_form_id: product_form_id, show_double_qty_btn: show_double_qty_btn %}
               </div>
             {% endif %}
             {% if enableCardButton %}

--- a/snippets/product-qty-input.liquid
+++ b/snippets/product-qty-input.liquid
@@ -39,15 +39,17 @@
     </button>
   </quantity-input>
 
-  {%- if show_double_qty_btn != false -%}
+  {%- if show_double_qty_btn -%}
     {%- assign min_qty = product.metafields.custom.minimum_quantity | default: 1 -%}
     {%- if min_qty > 1 or request.design_mode -%}
-    <button type="button"
+      <button
+        type="button"
         class="double-qty-btn sf__btn sf__btn-secondary flex-1 max-w-[160px]"
         aria-label="Adaugă {{ min_qty }} bucăți"
-        data-double-qty>
+        data-double-qty
+      >
         Adaugă {{ min_qty }} bucăți
-    </button>
+      </button>
     {%- endif -%}
   {%- endif -%}
 </div>


### PR DESCRIPTION
## Summary
- ensure `.double-qty-btn` renders only when explicitly enabled
- pass `show_double_qty_btn` to product form from various sections
- default to `false` in product form snippet

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889152e37e0832da83f886a6aa4cfe7