### PR TITLE
Update double qty button text

### DIFF
--- a/assets/double-qty.js
+++ b/assets/double-qty.js
@@ -53,8 +53,8 @@
   window.validateAndHighlightQty = validateAndHighlightQty;
 
   var BUTTON_CLASS = 'double-qty-btn';
-  var LABEL_PREFIX = 'Adaugă ';
-  var LABEL_SUFFIX = ' bucăți';
+  var LABEL_PREFIX = 'Adaugă încă ';
+  var LABEL_SUFFIX = '';
 
   function applyMinQty(){
     document.querySelectorAll('[data-min-qty]').forEach(function(input){

--- a/snippets/double-qty-btn.liquid
+++ b/snippets/double-qty-btn.liquid
@@ -12,9 +12,9 @@
 {% if min_qty > 1 or request.design_mode %}
 <button type="button"
         class="double-qty-btn sf__btn sf__btn-secondary"
-        aria-label="Adaugă {{ min_qty }} bucăți"
+        aria-label="Adaugă încă {{ min_qty }}"
         data-double-qty>
-    Adaugă {{ min_qty }} bucăți
+    Adaugă încă {{ min_qty }}
 </button>
 {% endif %}
 

--- a/snippets/product-qty-input.liquid
+++ b/snippets/product-qty-input.liquid
@@ -45,10 +45,10 @@
       <button
         type="button"
         class="double-qty-btn sf__btn sf__btn-secondary flex-1 max-w-[160px]"
-        aria-label="Adaugă {{ min_qty }} bucăți"
+        aria-label="Adaugă încă {{ min_qty }}"
         data-double-qty
       >
-        Adaugă {{ min_qty }} bucăți
+        Adaugă încă {{ min_qty }}
       </button>
     {%- endif -%}
   {%- endif -%}


### PR DESCRIPTION
## Summary
- update the double quantity button label to say `Adaugă încă` without `bucăți`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688924e3b3b4832d83780c3d9a632005