### PR TITLE
Add active scale effect to double-qty button

### DIFF
--- a/assets/double-qty.css
+++ b/assets/double-qty.css
@@ -13,22 +13,27 @@ Descriere: Stiluri responsive, accesibile, preia stilul principal al butoanelor 
   padding: 0.5em 1.2em;
   font-size: 1em;
   font-weight: 500;
-  background: var(--color-primary, #222);
-  color: var(--color-btn-text, #fff);
-  border: none;
-  border-radius: 4px;
+  background-color: transparent;
+  border: var(--btn-border-width, 1px) solid var(--color-btn-secondary-border, var(--color-primary-darker));
+  color: var(--color-btn-secondary-text, var(--color-body-text));
+  border-radius: var(--btn-border-radius, 5px);
   cursor: pointer;
-  transition: background 0.2s, box-shadow 0.2s;
-  box-shadow: 0 1px 4px rgba(0,0,0,0.08);
+  box-shadow: 0 1px 4px #00000014;
+  transition: transform 0.12s;
 }
-.double-qty-btn:focus {
-  outline: 2px solid var(--color-primary, #222);
-  outline-offset: 2px;
-  box-shadow: 0 0 0 2px var(--color-primary, #222);
+.double-qty-btn:is(:hover, :focus, :active, :disabled) {
+  background-color: inherit !important;
+  border-color: inherit !important;
+  border-width: inherit !important;
+  color: inherit !important;
+  border-radius: inherit !important;
+  box-shadow: inherit !important;
+  opacity: inherit !important;
+  cursor: inherit !important;
+  outline: none;
 }
-.double-qty-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
+.double-qty-btn:active {
+  transform: scale(0.98);
 }
 @media (max-width: 600px) {
   .double-qty-btn {


### PR DESCRIPTION
## Summary
- keep double-qty button appearance consistent across states using `inherit`
- preserve scaling effect on button press

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6889208cca24832db34aef654bc3ea04